### PR TITLE
fix: avoid put backpack inside itself

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>fun.felipe</groupId>
   <artifactId>PowerfulBackpacks</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>1.2.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>PowerfulBackpacks</name>

--- a/src/main/java/fun/felipe/powerfulbackpacks/events/PlayerInventoryListener.java
+++ b/src/main/java/fun/felipe/powerfulbackpacks/events/PlayerInventoryListener.java
@@ -21,7 +21,18 @@ public class PlayerInventoryListener implements Listener {
     @EventHandler
     public void onPlayerInventoryInteract(InventoryClickEvent event) {
         if (event.getClickedInventory() == null) return;
-        if (!event.getClick().isRightClick()) return;
+        if (!event.getClick().isRightClick()) {
+
+            if (event.getInventory().getHolder() instanceof BackpackGUI backpack) {
+                if (event.getCurrentItem() != null && event.getCurrentItem().equals(backpack.getBackpack())) {
+                    plugin.getLogger().warning(event.getWhoClicked().getName() + " tries to put a backpack inside itself");
+                    event.setCancelled(true);
+                    return;
+                }
+            }
+
+            return;
+        }
         if (event.getCurrentItem() == null) return;
         if (event.getCurrentItem().getType().equals(Material.BUNDLE)) event.setCancelled(true);
     }


### PR DESCRIPTION
Container paradox resolution. Avoid put backpack inside itself. Check if the clicked item is the same of the current backpack item.